### PR TITLE
ENH: Support multiple target columns

### DIFF
--- a/expandas/skaccessors/__init__.py
+++ b/expandas/skaccessors/__init__.py
@@ -4,6 +4,7 @@ from expandas.skaccessors.base import _maybe_sklearn_data
 
 from expandas.skaccessors.cluster import ClusterMethods
 from expandas.skaccessors.covariance import CovarianceMethods
+from expandas.skaccessors.cross_decomposition import CrossDecompositionMethods
 from expandas.skaccessors.cross_validation import CrossValidationMethods
 from expandas.skaccessors.decomposition import DecompositionMethods
 from expandas.skaccessors.ensemble import EnsembleMethods

--- a/expandas/skaccessors/cross_decomposition.py
+++ b/expandas/skaccessors/cross_decomposition.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from expandas.core.accessor import AccessorMethods
+
+
+class CrossDecompositionMethods(AccessorMethods):
+    """
+    Accessor to ``sklearn.cross_decomposition``.
+    """
+
+    _module_name = 'sklearn.cross_decomposition'
+
+    @classmethod
+    def _fit(cls, df, estimator, *args, **kwargs):
+        data = df.data.values
+        if df.has_target():
+            target = df.target.values
+            try:
+                result = estimator.fit(data, Y=target, *args, **kwargs)
+            except TypeError:
+                result = estimator.fit(data, *args, **kwargs)
+        else:
+            # not try to pass target if it doesn't exists
+            # to catch ValueError from estimator
+            result = estimator.fit(data, *args, **kwargs)
+        return result
+
+    @classmethod
+    def _transform(cls, df, estimator, *args, **kwargs):
+        data = df.data.values
+        if df.has_target():
+            target = df.target.values
+            try:
+                result = estimator.transform(data, Y=target, *args, **kwargs)
+                result = df._constructor(result[0], target=result[1])
+            except TypeError:
+                result = estimator.transform(data, *args, **kwargs)
+                result = df._constructor(result)
+        else:
+            # not try to pass target if it doesn't exists
+            # to catch ValueError from estimator
+            result = estimator.transform(data, *args, **kwargs)
+            result = df._constructor(result)
+        return result
+
+    @classmethod
+    def _predict(cls, df, estimator, *args, **kwargs):
+        data = df.data.values
+        result = estimator.predict(data, *args, **kwargs)
+        result = df._constructor(result)
+        return result

--- a/expandas/skaccessors/cross_decomposition.py
+++ b/expandas/skaccessors/cross_decomposition.py
@@ -20,10 +20,7 @@ class CrossDecompositionMethods(AccessorMethods):
         data = df.data.values
         if df.has_target():
             target = df.target.values
-            try:
-                result = estimator.fit(data, Y=target, *args, **kwargs)
-            except TypeError:
-                result = estimator.fit(data, *args, **kwargs)
+            result = estimator.fit(data, Y=target, *args, **kwargs)
         else:
             # not try to pass target if it doesn't exists
             # to catch ValueError from estimator

--- a/expandas/skaccessors/test/test_cross_decomposition.py
+++ b/expandas/skaccessors/test/test_cross_decomposition.py
@@ -20,6 +20,125 @@ class TestCrossDecomposition(tm.TestCase):
         self.assertIs(df.cross_decomposition.CCA, cd.CCA)
         self.assertIs(df.cross_decomposition.PLSSVD, cd.PLSSVD)
 
+    def test_PLSCannonical(self):
+        n = 500
+        np.random.seed(1)
+
+        # 2 latents vars:
+        l1 = np.random.normal(size=n)
+        l2 = np.random.normal(size=n)
+
+        latents = np.array([l1, l1, l2, l2]).T
+        X = latents + np.random.normal(size=4 * n).reshape((n, 4))
+        Y = latents + np.random.normal(size=4 * n).reshape((n, 4))
+
+        X_train = X[:n / 2]
+        Y_train = Y[:n / 2]
+        X_test = X[n / 2:]
+        Y_test = Y[n / 2:]
+
+        train = expd.ModelFrame(X_train, target=Y_train)
+        test = expd.ModelFrame(X_test, target=Y_test)
+        self.assertTrue(train.has_target())
+        expected = pd.Index(['.target 0', '.target 1', '.target 2', '.target 3'])
+        self.assert_index_equal(train.target_name, expected)
+        self.assertEqual(train.data.shape, X_train.shape)
+        self.assertEqual(train.target.shape, Y_train.shape)
+
+        plsca1 = train.cross_decomposition.PLSCanonical(n_components=2)
+        plsca2 = cd.PLSCanonical(n_components=2)
+
+        train.fit(plsca1)
+        plsca2.fit(X_train, Y_train)
+
+        result_tr = train.transform(plsca1)
+        result_test = test.transform(plsca1)
+
+        expected_tr = plsca2.transform(X_train, Y_train)
+        expected_test = plsca2.transform(X_test, Y_test)
+
+        self.assertTrue(isinstance(result_tr, expd.ModelFrame))
+        self.assertTrue(isinstance(result_test, expd.ModelFrame))
+        self.assert_numpy_array_equal(result_tr.data.values, expected_tr[0])
+        self.assert_numpy_array_equal(result_tr.target.values, expected_tr[1])
+        self.assert_numpy_array_equal(result_test.data.values, expected_test[0])
+        self.assert_numpy_array_equal(result_test.target.values, expected_test[1])
+
+    def test_CCA(self):
+        n = 500
+        np.random.seed(1)
+
+        # 2 latents vars:
+        l1 = np.random.normal(size=n)
+        l2 = np.random.normal(size=n)
+
+        latents = np.array([l1, l1, l2, l2]).T
+        X = latents + np.random.normal(size=4 * n).reshape((n, 4))
+        Y = latents + np.random.normal(size=4 * n).reshape((n, 4))
+
+        X_train = X[:n / 2]
+        Y_train = Y[:n / 2]
+        X_test = X[n / 2:]
+        Y_test = Y[n / 2:]
+
+        train = expd.ModelFrame(X_train, target=Y_train)
+        test = expd.ModelFrame(X_test, target=Y_test)
+        self.assertTrue(train.has_target())
+        expected = pd.Index(['.target 0', '.target 1', '.target 2', '.target 3'])
+        self.assert_index_equal(train.target_name, expected)
+        self.assertEqual(train.data.shape, X_train.shape)
+        self.assertEqual(train.target.shape, Y_train.shape)
+
+        cca1 = train.cross_decomposition.CCA(n_components=2)
+        cca2 = cd.CCA(n_components=2)
+
+        train.fit(cca1)
+        cca2.fit(X_train, Y_train)
+
+        result_tr = train.transform(cca1)
+        result_test = test.transform(cca1)
+
+        expected_tr = cca2.transform(X_train, Y_train)
+        expected_test = cca2.transform(X_test, Y_test)
+
+        self.assertTrue(isinstance(result_tr, expd.ModelFrame))
+        self.assertTrue(isinstance(result_test, expd.ModelFrame))
+        self.assert_numpy_array_equal(result_tr.data.values, expected_tr[0])
+        self.assert_numpy_array_equal(result_tr.target.values, expected_tr[1])
+        self.assert_numpy_array_equal(result_test.data.values, expected_test[0])
+        self.assert_numpy_array_equal(result_test.target.values, expected_test[1])
+
+    def test_PLSRegression(self):
+
+        n = 1000
+        q = 3
+        p = 10
+        X = np.random.normal(size=n * p).reshape((n, p))
+        B = np.array([[1, 2] + [0] * (p - 2)] * q).T
+        # each Yj = 1*X1 + 2*X2 + noize
+        Y = np.dot(X, B) + np.random.normal(size=n * q).reshape((n, q)) + 5
+
+        df = expd.ModelFrame(X, target=Y)
+        pls1 = df.cross_decomposition.PLSRegression(n_components=3)
+        df.fit(pls1)
+        result = df.predict(pls1)
+
+        pls2 = cd.PLSRegression(n_components=3)
+        pls2.fit(X, Y)
+        expected = pls2.predict(X)
+
+        self.assertTrue(isinstance(result, expd.ModelFrame))
+        self.assert_numpy_array_almost_equal(result.values, expected)
+
+"""
+###############################################################################
+# CCA (PLS mode B with symmetric deflation)
+
+cca = CCA(n_components=2)
+cca.fit(X_train, Y_train)
+X_train_r, Y_train_r = plsca.transform(X_train, Y_train)
+X_test_r, Y_test_r = plsca.transform(X_test, Y_test)
+"""
 
 if __name__ == '__main__':
     import nose

--- a/expandas/skaccessors/test/test_gaussian_process.py
+++ b/expandas/skaccessors/test/test_gaussian_process.py
@@ -88,6 +88,47 @@ class TestGaussianProcess(tm.TestCase):
 
         self.assert_numpy_array_almost_equal(y_result, y_expected)
 
+    def test_Gaussian2D(self):
+
+        from scipy import stats
+
+        # Standard normal distribution functions
+        phi = stats.distributions.norm().pdf
+        PHI = stats.distributions.norm().cdf
+        PHIinv = stats.distributions.norm().ppf
+
+        # A few constants
+        lim = 8
+
+        def g(x):
+            """The function to predict (classification will then consist in predicting
+            whether g(x) <= 0 or not)"""
+            return 5. - x[:, 1] - .5 * x[:, 0] ** 2.
+
+        # Design of experiments
+        X = np.array([[-4.61611719, -6.00099547],
+                      [4.10469096, 5.32782448],
+                      [0.00000000, -0.50000000],
+                      [-6.17289014, -4.6984743],
+                      [1.3109306, -6.93271427],
+                      [-5.03823144, 3.10584743],
+                      [-2.87600388, 6.74310541],
+                      [5.21301203, 4.26386883]])
+        y = g(X)
+
+        df = expd.ModelFrame(X, target=y)
+        gpm1 = df.gaussian_process.GaussianProcess(theta0=5e-1)
+        df.fit(gpm1)
+        result, result_MSE = df.predict(gpm1, eval_MSE=True)
+
+        gpm2 = gp.GaussianProcess(theta0=5e-1)
+        gpm2.fit(X, y)
+        expected, expected_MSE = gpm2.predict(X, eval_MSE=True)
+
+        self.assert_numpy_array_almost_equal(result.values, expected)
+        self.assert_numpy_array_almost_equal(result_MSE.values, expected_MSE)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/expandas/skaccessors/test/test_preprocessing.py
+++ b/expandas/skaccessors/test/test_preprocessing.py
@@ -332,6 +332,34 @@ class TestPreprocessing(tm.TestCase):
         self.assert_numpy_array_equal(inversed.values.flatten(), arr)
         self.assert_index_equal(result.index, pd.Index(['a', 'b', 'c', 'd']))
 
+    def test_LabelBinarizer(self):
+        arr = np.array(['X', 'Y', 'Z', 'X'])
+        s = expd.ModelSeries(arr)
+
+        lb = s.preprocessing.LabelBinarizer()
+        s.fit(lb)
+
+        binarized = s.transform(lb)
+        self.assertTrue(isinstance(binarized, expd.ModelFrame))
+
+        expected = pd.DataFrame({0: [1, 0, 0, 1], 1: [0, 1, 0, 0], 2: [0, 0, 1, 0]})
+        self.assert_frame_equal(binarized, expected)
+
+        df = expd.ModelFrame(datasets.load_iris())
+        df.target.fit(lb)
+        binarized = df.target.transform(lb)
+
+        expected = pd.DataFrame({0: [1] * 50 + [0] * 100,
+                                 1: [0] * 50 + [1] * 50 + [0] * 50,
+                                 2: [0] * 100 + [1] * 50})
+        self.assert_frame_equal(binarized, expected)
+
+        df = expd.ModelFrame(datasets.load_iris())
+        df.target.fit(lb)
+        df.target = df.target.transform(lb)
+        self.assertEqual(df.shape, (150, 7))
+        self.assert_frame_equal(df.target, expected)
+
 
 if __name__ == '__main__':
     import nose

--- a/expandas/test/test_frame.py
+++ b/expandas/test/test_frame.py
@@ -731,10 +731,9 @@ class TestModelFrameMultiTarges(tm.TestCase):
                                'x3': [25, 26, 27]},
                                index=['a', 'b', 'c'])
 
-        with tm.assert_produces_warning(UserWarning):
-            # when the target has the different length as the target_name,
-            # target is being replaced
-            mdf.target = target
+        # when the target has the different length as the target_name,
+        # target is being replaced
+        mdf.target = target
 
         self.assertTrue(isinstance(mdf, expd.ModelFrame))
         self.assertEqual(mdf.shape, (3, 6))

--- a/expandas/test/test_frame.py
+++ b/expandas/test/test_frame.py
@@ -701,7 +701,8 @@ class TestModelFrameMultiTarges(tm.TestCase):
                                index=['a', 'b', 'c'])
 
         with tm.assert_produces_warning(UserWarning):
-            # target is renamed to existing target ['t1', 't2']
+            # when the target has the same length as the target_name,
+            # is renamed to existing target ['t1', 't2']
             mdf.target = target
 
         self.assertTrue(isinstance(mdf, expd.ModelFrame))
@@ -730,8 +731,29 @@ class TestModelFrameMultiTarges(tm.TestCase):
                                'x3': [25, 26, 27]},
                                index=['a', 'b', 'c'])
 
-        with self.assertRaisesRegexp(ValueError, 'target and target_name are unmatched'):
+        with tm.assert_produces_warning(UserWarning):
+            # when the target has the different length as the target_name,
+            # target is being replaced
             mdf.target = target
+
+        self.assertTrue(isinstance(mdf, expd.ModelFrame))
+        self.assertEqual(mdf.shape, (3, 6))
+        expected =  pd.DataFrame({'x1': [20, 21, 22],
+                                  'x2': [23, 24, 25],
+                                  'x3': [25, 26, 27],
+                                  'A': [1, 2, 3],
+                                  'B': [4, 5, 6],
+                                  'C': [7, 8, 9]},
+                           index=['a', 'b', 'c'],
+                           columns=['x1', 'x2', 'x3', 'A', 'B', 'C'])
+        self.assert_frame_equal(mdf, expected)
+        self.assert_index_equal(mdf.index, pd.Index(['a', 'b', 'c']))
+        self.assert_index_equal(mdf.columns, pd.Index(['x1', 'x2', 'x3', 'A', 'B', 'C']))
+        self.assert_frame_equal(mdf.data, df)
+        self.assert_frame_equal(mdf.target, target)
+        self.assert_index_equal(mdf.target.columns, pd.Index(['x1', 'x2', 'x3']))
+        self.assert_index_equal(mdf.target_name, pd.Index(['x1', 'x2', 'x3']))
+        self.assertTrue(mdf.has_multi_targets())
 
 
 if __name__ == '__main__':

--- a/expandas/test/test_frame.py
+++ b/expandas/test/test_frame.py
@@ -754,6 +754,26 @@ class TestModelFrameMultiTarges(tm.TestCase):
         self.assert_index_equal(mdf.target_name, pd.Index(['x1', 'x2', 'x3']))
         self.assertTrue(mdf.has_multi_targets())
 
+    def test_frame_init_df_duplicated_columns(self):
+        # initialization by dataframe and dataframe which have same columns
+        df = pd.DataFrame({'A': [1, 2, 3],
+                           'B': [4, 5, 6],
+                           'C': [7, 8, 9]})
+        target = pd.DataFrame({'A': [10, 11, 12],
+                               'B': [13, 14, 15]})
+
+        mdf = expd.ModelFrame(df, target=target)
+
+        cols = pd.MultiIndex.from_tuples([('.target', 'A'), ('.target', 'B'),
+                                          ('.data', 'A'), ('.data', 'B'), ('.data', 'C')])
+        expected = pd.DataFrame({('.target', 'A'): [10, 11, 12],
+                                 ('.target', 'B'): [13, 14, 15],
+                                 ('.data', 'A'): [1, 2, 3],
+                                 ('.data', 'B'): [4, 5, 6],
+                                 ('.data', 'C'): [7, 8, 9]},
+                                columns=cols)
+        self.assert_frame_equal(mdf, expected)
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
Closes #34.

- [x] Initialize target with ``DataFrame`` likes.
- [x] Set default ``target`` column names.
- [x] Tests for ``sklearn.preprocessing.LabelBinarizer``
- [x] Tests for ``sklearn.cross_decomposition``
- [x] Tests for ``sklearn.gaussian_process``